### PR TITLE
bindings/python: Update build to Numpy 2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,9 @@ jobs:
                 libflac-dev                 \
                 libpcre2-dev                \
                 libpython3-dev              \
-                python3-numpy-dev           \
+                python3-pip                 \
                 wget
+        pip3 install --break-system-packages "numpy>=2.0"
         echo CC=gcc-14 >> $GITHUB_ENV
         echo CXX=g++-14 >> $GITHUB_ENV
         echo PREFIX=/usr >> $GITHUB_ENV
@@ -39,7 +40,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install automake libtool gcc pcre pcre2 xz flac python@3.12
-        pip3.12 install setuptools "numpy<2" --break-system-packages
+        pip3.12 install setuptools "numpy>=2.0" --break-system-packages
         echo CC=gcc-14 >> $GITHUB_ENV
         echo CXX=g++-14 >> $GITHUB_ENV
         echo FC=gfortran-14 >> $GITHUB_ENV

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -15,35 +15,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macos-13 is an intel runner, macos-14 is apple silicon
-          - os: macos-13
+          # macos-15-intel for x86_64 (min macOS 15.0), macos-14 for ARM (min macOS 14.0)
+          - os: macos-15-intel
             python: '3.8'
             build: 'cp38-macosx_x86_64'
-            target: '13.0'
+            target: '15.0'
             prefix: /usr/local
 
-          - os: macos-13
+          - os: macos-15-intel
             python: '3.9'
             build: 'cp39-macosx_x86_64'
-            target: '13.0'
+            target: '15.0'
             prefix: /usr/local
 
-          - os: macos-13
+          - os: macos-15-intel
             python: '3.10'
             build: 'cp310-macosx_x86_64'
-            target: '13.0'
+            target: '15.0'
             prefix: /usr/local
 
-          - os: macos-13
+          - os: macos-15-intel
             python: '3.11'
             build: 'cp311-macosx_x86_64'
-            target: '13.0'
+            target: '15.0'
             prefix: /usr/local
 
-          - os: macos-13
+          - os: macos-15-intel
             python: '3.12'
             build: 'cp312-macosx_x86_64'
-            target: '13.0'
+            target: '15.0'
             prefix: /usr/local
 
           - os: macos-14

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -114,7 +114,7 @@ jobs:
             .github/workflows/bootstrap.sh --disable-python &&
             make
           CIBW_BEFORE_BUILD: >
-            python -m pip install oldest-supported-numpy &&
+            python -m pip install "numpy>=2.0" &&
             .github/workflows/bootstrap.sh &&
             make -C bindings/python pyconstants.c
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,12 +17,6 @@ jobs:
         include:
           # macos-15-intel for x86_64 (min macOS 15.0), macos-14 for ARM (min macOS 14.0)
           - os: macos-15-intel
-            python: '3.8'
-            build: 'cp38-macosx_x86_64'
-            target: '15.0'
-            prefix: /usr/local
-
-          - os: macos-15-intel
             python: '3.9'
             build: 'cp39-macosx_x86_64'
             target: '15.0'
@@ -104,7 +98,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse bindings/python
         env:
           CIBW_BUILD: ${{ matrix.build }}
-          CIBW_SKIP: cp36* cp37* cp313*
+          CIBW_SKIP: cp36* cp37* cp38*
           CIBW_BEFORE_ALL_LINUX: >
             yum install -y bzip2-devel flac-devel xz-devel pcre-devel zziplib-devel &&
             .github/workflows/bootstrap.sh --disable-python &&

--- a/bindings/python/gdpy_intern.h
+++ b/bindings/python/gdpy_intern.h
@@ -30,8 +30,12 @@
 
 #ifdef GDPY_INCLUDE_NUMPY
 # ifdef HAVE_NUMPY_ARRAYOBJECT_H
+#  define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #  define PY_ARRAY_UNIQUE_SYMBOL gdpy_array_api
 #  include <numpy/arrayobject.h>
+#  if NPY_ABI_VERSION < 0x02000000
+#   error "NumPy 2.0 or later is required. Please upgrade NumPy: pip install 'numpy>=2.0'"
+#  endif
 # endif
 #endif
 

--- a/bindings/python/pygetdata.c
+++ b/bindings/python/pygetdata.c
@@ -600,40 +600,40 @@ int gdpy_npytype_from_type(gd_type_t type)
   switch(type)
   {
     case GD_UINT8:
-      npytype = PyArray_UINT8;
+      npytype = NPY_UINT8;
       break;
     case GD_INT8:
-      npytype = PyArray_INT8;
+      npytype = NPY_INT8;
       break;
     case GD_UINT16:
-      npytype = PyArray_UINT16;
+      npytype = NPY_UINT16;
       break;
     case GD_INT16:
-      npytype = PyArray_INT16;
+      npytype = NPY_INT16;
       break;
     case GD_UINT32:
-      npytype = PyArray_UINT32;
+      npytype = NPY_UINT32;
       break;
     case GD_INT32:
-      npytype = PyArray_INT32;
+      npytype = NPY_INT32;
       break;
     case GD_UINT64:
-      npytype = PyArray_UINT64;
+      npytype = NPY_UINT64;
       break;
     case GD_INT64:
-      npytype = PyArray_INT64;
+      npytype = NPY_INT64;
       break;
     case GD_FLOAT32:
-      npytype = PyArray_FLOAT32;
+      npytype = NPY_FLOAT32;
       break;
     case GD_FLOAT64:
-      npytype = PyArray_FLOAT64;
+      npytype = NPY_FLOAT64;
       break;
     case GD_COMPLEX64:
-      npytype = PyArray_COMPLEX64;
+      npytype = NPY_COMPLEX64;
       break;
     case GD_COMPLEX128:
-      npytype = PyArray_COMPLEX128;
+      npytype = NPY_COMPLEX128;
       break;
     default:
       npytype = NPY_NOTYPE;

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "setuptools-scm", "wheel", "oldest-supported-numpy"]
+requires = ["setuptools", "setuptools-scm", "wheel", "numpy>=2.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "pygetdata"
-dependencies = ["numpy<2.0"]
+dependencies = ["numpy>=1.7"]
 dynamic = ["version"]
 
 [tool.setuptools]


### PR DESCRIPTION
Because Numpy 2.x shared libraries are ABI compatible back to Numpy 1.x, this requires a newer build environment to produce the Python bindings, but the resulting library is backwards compatible. (This is ideal for a wheel-based flow.)